### PR TITLE
Allow the consumer to receive customised information from the server

### DIFF
--- a/plugin-update-checker.php
+++ b/plugin-update-checker.php
@@ -845,7 +845,9 @@ class PluginUpdate_1_3 {
 	 */
 	public static function fromObject($object) {
 		$update = new self();
-		foreach(self::$fields as $field){
+		$fields = self::$fields;
+		if (!empty($object->slug)) $fields = apply_filters('puc_retain_fields-'.$object->slug, $fields);
+		foreach($fields as $field){
 			$update->$field = $object->$field;
 		}
 		return $update;
@@ -861,7 +863,9 @@ class PluginUpdate_1_3 {
 	 */
 	public function toStdClass() {
 		$object = new StdClass();
-		foreach(self::$fields as $field){
+		$fields = self::$fields;
+		if (!empty($this->slug)) $fields = apply_filters('puc_retain_fields-'.$this->slug, $fields);
+		foreach($fields as $field){
 			$object->$field = $this->$field;
 		}
 		return $object;


### PR DESCRIPTION
I have a need to receive extra information back from the server. In particular, I want to receive information that says "updates entitlement soon expires" or "updates entitlement already expired".

Currently, the functions in the class PluginUpdate_1_3 strip out anything not in the private $fields.

This change adds a filter to allow the consumer to retain any extra fields they wish.
