### PR TITLE
Prevent PHP warnings

### DIFF
--- a/plugin-update-checker.php
+++ b/plugin-update-checker.php
@@ -848,7 +848,7 @@ class PluginUpdate_1_3 {
 		$fields = self::$fields;
 		if (!empty($object->slug)) $fields = apply_filters('puc_retain_fields-'.$object->slug, $fields);
 		foreach($fields as $field){
-			$update->$field = $object->$field;
+			if (isset($object->$field)) $update->$field = $object->$field;
 		}
 		return $update;
 	}


### PR DESCRIPTION
The recent addition of the filter makes it possible for some values in $object to not exist; leading to PHP warnings. This change prevents these.
