### PR TITLE
Don't fail on missing debug-bar-plugin.php

### DIFF
--- a/plugin-update-checker.php
+++ b/plugin-update-checker.php
@@ -878,8 +878,9 @@ class PluginUpdateChecker_2_2 {
 	 * Initialize the update checker Debug Bar plugin/add-on thingy.
 	 */
 	public function initDebugBarPanel() {
-		if ( class_exists('Debug_Bar', false) ) {
-			require_once dirname(__FILE__) . '/debug-bar-plugin.php';
+		$debugBarPlugin = dirname(__FILE__) . '/debug-bar-plugin.php';
+		if ( class_exists('Debug_Bar', false) && file_exists( $debugBarPlugin ) ) {
+			require_once $debugBarPlugin;
 			$this->debugBarPlugin = new PucDebugBarPlugin($this);
 		}
 	}


### PR DESCRIPTION
First of all thanks for the library, works like a charm!

There is a small issue though which I think is worth to be fixed in the main code base.

Update checker integrates with Debug Bar plugin which is useful sometimes on dev staging. However, I never want that to happen for end-users of my plugin if even they have Debug Bar active. It seems they use debug bar for their own needs and don't want to debug my plugin internals. That's why I strip out all files related to debug bar with a build script before releasing a new plugin version. 

However, missing `debug-bar-plugin.php` file causes a fatal error if Debug Bar plugin is active. The PR fixes this issue.

To sum up there are 2 points:
1. Don't mess with end-user's Debug Bar
2. Never fail on auxiliary debug things which `debug-bar-plugin.php` is.

Does that make sense?