### PR TITLE
Add support for `is-dismissible` class

### DIFF
--- a/plugin-update-checker.php
+++ b/plugin-update-checker.php
@@ -818,7 +818,7 @@ class PluginUpdateChecker_2_3 {
 				$message = sprintf('Unknown update checker status "%s"', htmlentities($status));
 			}
 			printf(
-				'<div class="updated"><p>%s</p></div>',
+				'<div class="updated notice is-dismissible"><p>%s</p></div>',
 				apply_filters('puc_manual_check_message-' . $this->slug, $message, $status)
 			);
 		}


### PR DESCRIPTION
Adding the `is-dismissible` class introduced in [WordPress 4.2](https://make.wordpress.org/core/2015/04/23/spinners-and-dismissible-admin-notices-in-4-2/). The admin notice displayed after the update check can now be dismissed.

Solves [Issue #49](https://github.com/YahnisElsts/plugin-update-checker/issues/49)