### PR TITLE
Make wp_remote_get result filterable

### DIFF
--- a/Puc/v4p1/UpdateChecker.php
+++ b/Puc/v4p1/UpdateChecker.php
@@ -460,6 +460,8 @@ if ( !class_exists('Puc_v4p1_UpdateChecker', false) ):
 
 			$result = wp_remote_get($url, $options);
 
+			$result = apply_filters($this->getUniqueName('http_result'), $result, $url, $options);
+			
 			//Try to parse the response
 			$status = $this->validateApiResponse($result);
 			$metadata = null;

--- a/Puc/v4p1/UpdateChecker.php
+++ b/Puc/v4p1/UpdateChecker.php
@@ -460,7 +460,7 @@ if ( !class_exists('Puc_v4p1_UpdateChecker', false) ):
 
 			$result = wp_remote_get($url, $options);
 
-			$result = apply_filters($this->getUniqueName('http_result'), $result, $url, $options);
+			$result = apply_filters($this->getUniqueName('request_metadata_http_result'), $result, $url, $options);
 			
 			//Try to parse the response
 			$status = $this->validateApiResponse($result);


### PR DESCRIPTION
I want to filter the wp_remote_get result. In my use-case, if https fails, I switch back to http (in case the user had a bad curl setup/obsolete SSL certificates) and try again.

Until now I've been patching the code, but that is, of course, silly!