### PR TITLE
Force evaluation order for PHP 7 compat

### DIFF
--- a/vendor/ParsedownLegacy.php
+++ b/vendor/ParsedownLegacy.php
@@ -1409,7 +1409,7 @@ class Parsedown
 
             if (isset($Element['handler']))
             {
-                $markup .= $this->$Element['handler']($Element['text']);
+                $markup .= $this->{$Element['handler']}($Element['text']);
             }
             else
             {


### PR DESCRIPTION
As per http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect

In PHP 7, indirect access to variables, properties, and methods is now evaluated strictly in left-to-right order. Code that used the old right-to-left evaluation order must be rewritten to explicitly use that evaluation order with curly braces