### PR TITLE
Work on WP versions without wp_normalize_path()

### DIFF
--- a/Puc/v4/Factory.php
+++ b/Puc/v4/Factory.php
@@ -116,7 +116,7 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		 * @param string $path Path to normalize.
 		 * @return string Normalized path.
 		 */
-		protected static function normalizePath($path) {
+		public static function normalizePath($path) {
 			if ( function_exists('wp_normalize_path') ) {
 				return wp_normalize_path($path);
 			}

--- a/Puc/v4/Factory.php
+++ b/Puc/v4/Factory.php
@@ -35,7 +35,7 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		 * @return Puc_v4p2_Plugin_UpdateChecker|Puc_v4p2_Theme_UpdateChecker|Puc_v4p2_Vcs_BaseChecker
 		 */
 		public static function buildUpdateChecker($metadataUrl, $fullPath, $slug = '', $checkPeriod = 12, $optionName = '', $muPluginFile = '') {
-			$fullPath = self::wp_normalize_path($fullPath);
+			$fullPath = self::normalizePath($fullPath);
 			$id = null;
 
 			//Plugin or theme?
@@ -111,18 +111,18 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		 *
 		 * Normalize a filesystem path. Introduced in WP 3.9.
 		 * Copying here allows use of the class on earlier versions.
-		 * This version taken from WP 4.8.2 (unchanged since 4.5.0)
+		 * This version adapted from WP 4.8.2 (unchanged since 4.5.0)
 		 *
 		 * @param string $path Path to normalize.
 		 * @return string Normalized path.
 		 */
-		protected static function wp_normalize_path($path) {
+		protected static function normalizePath($path) {
 			if ( function_exists('wp_normalize_path') ) {
 				return wp_normalize_path($path);
 			}
 			$path = str_replace('\\', '/', $path);
 			$path = preg_replace('|(?<=.)/+|', '/', $path);
-			if ( ':' === substr($path, 1, 1) ) {
+			if ( substr($path, 1, 1) === ':' ) {
 				$path = ucfirst($path);
 			}
 			return $path;
@@ -136,8 +136,8 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		 */
 		protected static function isPluginFile($absolutePath) {
 			//Is the file inside the "plugins" or "mu-plugins" directory?
-			$pluginDir = self::wp_normalize_path(WP_PLUGIN_DIR);
-			$muPluginDir = self::wp_normalize_path(WPMU_PLUGIN_DIR);
+			$pluginDir = self::normalizePath(WP_PLUGIN_DIR);
+			$muPluginDir = self::normalizePath(WPMU_PLUGIN_DIR);
 			if ( (strpos($absolutePath, $pluginDir) === 0) || (strpos($absolutePath, $muPluginDir) === 0) ) {
 				return true;
 			}

--- a/Puc/v4/Factory.php
+++ b/Puc/v4/Factory.php
@@ -35,7 +35,7 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		 * @return Puc_v4p2_Plugin_UpdateChecker|Puc_v4p2_Theme_UpdateChecker|Puc_v4p2_Vcs_BaseChecker
 		 */
 		public static function buildUpdateChecker($metadataUrl, $fullPath, $slug = '', $checkPeriod = 12, $optionName = '', $muPluginFile = '') {
-			$fullPath = wp_normalize_path($fullPath);
+			$fullPath = self::wp_normalize_path($fullPath);
 			$id = null;
 
 			//Plugin or theme?
@@ -108,6 +108,27 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		}
 
 		/**
+		 *
+		 * Normalize a filesystem path. Introduced in WP 3.9.
+		 * Copying here allows use of the class on earlier versions.
+		 * This version taken from WP 4.8.2 (unchanged since 4.5.0)
+		 *
+		 * @param string $path Path to normalize.
+		 * @return string Normalized path.
+		 */
+		protected static function wp_normalize_path($path) {
+			if ( function_exists('wp_normalize_path') ) {
+				return wp_normalize_path($path);
+			}
+			$path = str_replace('\\', '/', $path);
+			$path = preg_replace('|(?<=.)/+|', '/', $path);
+			if ( ':' === substr($path, 1, 1) ) {
+				$path = ucfirst($path);
+			}
+			return $path;
+		}
+		
+		/**
 		 * Check if the path points to a plugin file.
 		 *
 		 * @param string $absolutePath Normalized path.
@@ -115,8 +136,8 @@ if ( !class_exists('Puc_v4_Factory', false) ):
 		 */
 		protected static function isPluginFile($absolutePath) {
 			//Is the file inside the "plugins" or "mu-plugins" directory?
-			$pluginDir = wp_normalize_path(WP_PLUGIN_DIR);
-			$muPluginDir = wp_normalize_path(WPMU_PLUGIN_DIR);
+			$pluginDir = self::wp_normalize_path(WP_PLUGIN_DIR);
+			$muPluginDir = self::wp_normalize_path(WPMU_PLUGIN_DIR);
 			if ( (strpos($absolutePath, $pluginDir) === 0) || (strpos($absolutePath, $muPluginDir) === 0) ) {
 				return true;
 			}

--- a/Puc/v4p2/DebugBar/Extension.php
+++ b/Puc/v4p2/DebugBar/Extension.php
@@ -94,7 +94,7 @@ if ( !class_exists('Puc_v4p2_DebugBar_Extension', false) ):
 
 			$pluginDir = Puc_v4_Factory::normalizePath(WP_PLUGIN_DIR);
 			$muPluginDir = Puc_v4_Factory::normalizePath(WPMU_PLUGIN_DIR);
-			$themeDir = Puc_v4_Factory(get_theme_root());
+			$themeDir = Puc_v4_Factory::normalizePath(get_theme_root());
 
 			if ( (strpos($absolutePath, $pluginDir) === 0) || (strpos($absolutePath, $muPluginDir) === 0) ) {
 				//It's part of a plugin.

--- a/Puc/v4p2/DebugBar/Extension.php
+++ b/Puc/v4p2/DebugBar/Extension.php
@@ -90,11 +90,11 @@ if ( !class_exists('Puc_v4p2_DebugBar_Extension', false) ):
 			$absolutePath = realpath(dirname(__FILE__) . '/../../../' . ltrim($filePath, '/'));
 
 			//Where is the library located inside the WordPress directory structure?
-			$absolutePath = wp_normalize_path($absolutePath);
+			$absolutePath = Puc_v4_Factory::normalizePath($absolutePath);
 
-			$pluginDir = wp_normalize_path(WP_PLUGIN_DIR);
-			$muPluginDir = wp_normalize_path(WPMU_PLUGIN_DIR);
-			$themeDir = wp_normalize_path(get_theme_root());
+			$pluginDir = Puc_v4_Factory::normalizePath(WP_PLUGIN_DIR);
+			$muPluginDir = Puc_v4_Factory::normalizePath(WPMU_PLUGIN_DIR);
+			$themeDir = Puc_v4_Factory(get_theme_root());
 
 			if ( (strpos($absolutePath, $pluginDir) === 0) || (strpos($absolutePath, $muPluginDir) === 0) ) {
 				//It's part of a plugin.


### PR DESCRIPTION
WP < 3.9 does not have the wp_normalize_path() function available. This edit restores the ability to work on such versions, by bringing that small function in.
(The main reason we see people installing on such versions is to backup the site, prior to updating it to something more modern).