### PR TITLE
Use a WP 3.7+ function conditionally

### DIFF
--- a/Puc/v4p2/UpdateChecker.php
+++ b/Puc/v4p2/UpdateChecker.php
@@ -569,6 +569,9 @@ if ( !class_exists('Puc_v4p2_UpdateChecker', false) ):
 		 * @return array
 		 */
 		protected function getInstalledTranslations() {
+			if ( !function_exists('wp_get_installed_translations') ) {
+				return array();
+			}
 			$installedTranslations = wp_get_installed_translations($this->translationType . 's');
 			if ( isset($installedTranslations[$this->directoryName]) ) {
 				$installedTranslations = $installedTranslations[$this->directoryName];


### PR DESCRIPTION
`wp_get_installed_translations()` was introduced in WP 3.7. This change returns an empty result for the translations list if the function does not exist. (Encountered in the wild, fatal error).