### PR TITLE
Ajout langue fr_CA

### DIFF
--- a/languages/plugin-update-checker-fr_CA.mo
+++ b/languages/plugin-update-checker-fr_CA.mo
@@ -1,0 +1,16 @@
+Þ•          T      Œ       ¸      ¹       Ë   "   ì   =     E   M  -   “  ä  Á     ¦  4   Â  %   ÷  8     F   V                                             Check for updates There is no changelog available. Unknown update checker status "%s" the plugin titleA new version of the %s plugin is available. the plugin titleCould not determine if updates are available for %s. the plugin titleThe %s plugin is up to date. Project-Id-Version: plugin-update-checker
+POT-Creation-Date: 2017-11-24 17:02+0200
+PO-Revision-Date: 2018-02-12 10:32-0500
+Language-Team: 
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+X-Generator: Poedit 2.0.4
+X-Poedit-Basepath: ..
+Plural-Forms: nplurals=2; plural=(n > 1);
+X-Poedit-SourceCharset: UTF-8
+X-Poedit-KeywordsList: __;_e;_x:1,2c;_x
+Last-Translator: devanonyme <devanonyme@gmail.com>
+Language: fr_CA
+X-Poedit-SearchPath-0: .
+ VÃ©rifier les mises Ã  jour Il nâ€™y a aucun journal de mise Ã  jour disponible. Un problÃ¨me inconnu est survenu "%s" Une nouvelle version de lâ€™extension %s est disponible. Impossible de dÃ©terminer si une mise Ã  jour est disponible pour "%s" Lâ€™extension %s est Ã  jour. 

--- a/languages/plugin-update-checker-fr_CA.po
+++ b/languages/plugin-update-checker-fr_CA.po
@@ -1,0 +1,48 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: plugin-update-checker\n"
+"POT-Creation-Date: 2017-11-24 17:02+0200\n"
+"PO-Revision-Date: 2018-02-12 10:32-0500\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.4\n"
+"X-Poedit-Basepath: ..\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_x:1,2c;_x\n"
+"Last-Translator: devanonyme <devanonyme <devanonyme@gmail.com>\n"
+"Language: fr_CA\n"
+"X-Poedit-SearchPath-0: .\n"
+
+#: Puc/v4p3/Plugin/UpdateChecker.php:395
+msgid "Check for updates"
+msgstr "Vérifier les mises à jour"
+
+#: Puc/v4p3/Plugin/UpdateChecker.php:548
+#, php-format
+msgctxt "the plugin title"
+msgid "The %s plugin is up to date."
+msgstr "L’extension %s est à jour."
+
+#: Puc/v4p3/Plugin/UpdateChecker.php:550
+#, php-format
+msgctxt "the plugin title"
+msgid "A new version of the %s plugin is available."
+msgstr "Une nouvelle version de l’extension %s est disponible."
+
+#: Puc/v4p3/Plugin/UpdateChecker.php:552
+#, php-format
+msgctxt "the plugin title"
+msgid "Could not determine if updates are available for %s."
+msgstr "Impossible de déterminer si une mise à jour est disponible pour \"%s\""
+
+#: Puc/v4p3/Plugin/UpdateChecker.php:558
+#, php-format
+msgid "Unknown update checker status \"%s\""
+msgstr "Un problème inconnu est survenu \"%s\""
+
+#: Puc/v4p3/Vcs/PluginUpdateChecker.php:95
+msgid "There is no changelog available."
+msgstr "Il n’y a aucun journal de mise à jour disponible."


### PR DESCRIPTION
WordPress use english as fallback if fr_CA is not there.
Add the required files, a copy of fr_FA + missing translation.