### PR TITLE
Add port host support for GitlabAPI

### DIFF
--- a/Puc/v4p4/Vcs/GitLabApi.php
+++ b/Puc/v4p4/Vcs/GitLabApi.php
@@ -27,9 +27,9 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 			//Parse the repository host to support custom hosts.
 			$port = @parse_url($repositoryUrl, PHP_URL_PORT);
 			if ( !empty($port) ){
-				$port = ':'.$port;
+				$port = ':' . $port;
 			}
-			$this->repositoryHost = @parse_url($repositoryUrl, PHP_URL_HOST).$port;
+			$this->repositoryHost = @parse_url($repositoryUrl, PHP_URL_HOST) . $port;
 
 			//Find the repository information
 			$path = @parse_url($repositoryUrl, PHP_URL_PATH);

--- a/Puc/v4p4/Vcs/GitLabApi.php
+++ b/Puc/v4p4/Vcs/GitLabApi.php
@@ -25,7 +25,11 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 
 		public function __construct($repositoryUrl, $accessToken = null) {
 			//Parse the repository host to support custom hosts.
-			$this->repositoryHost = @parse_url($repositoryUrl, PHP_URL_HOST);
+			$port = @parse_url($repositoryUrl, PHP_URL_PORT);
+			if ( !empty($port) ){
+				$port = ':'.$port;
+			}
+			$this->repositoryHost = @parse_url($repositoryUrl, PHP_URL_HOST).$port;
 
 			//Find the repository information
 			$path = @parse_url($repositoryUrl, PHP_URL_PATH);


### PR DESCRIPTION
Hi,

Thanks for this plugin, he is very helpful !
I have a self-hosted instances of GitLab but my URL is : http://www.gitlab.domain.com:8082/

When I try to check new update, i have errors (404 not found).
The plugin check this URL : http://www.gitlab.domain.com/user/repo
But not : http://www.gitlab.domain.com:8082/user/repo

So this is my contribution for support port in host.
Let me know if this is not helpful :-)
