### PR TITLE
Fix WordPress reporting unknown compatibility of a plugin/theme update

### DIFF
--- a/Puc/v4p4/UpdateChecker.php
+++ b/Puc/v4p4/UpdateChecker.php
@@ -301,6 +301,14 @@ if ( !class_exists('Puc_v4p4_UpdateChecker', false) ):
 			//Let plugins/themes modify the update.
 			$update = apply_filters($this->getUniqueName('request_update_result'), $update, $httpResult);
 
+			// "Tested up to" field in the plugin metadata is supposed to be in form of "major.minor",
+			// while WordPress core's list_plugin_updates() expects the $update->tested field to be
+			// the exact version, e.g. "major.minor.patch", to say it's compatible. In other case it would
+			// show "Compatibility: Unknown". That kinda mimics how wordpress.org API handles the "tested" field.
+			if (isset($update->tested) && preg_match('/^\d+\.\d+$/', $update->tested)) {
+				$update->tested .= ".999";
+			}
+
 			if ( isset($update, $update->translations) ) {
 				//Keep only those translation updates that apply to this site.
 				$update->translations = $this->filterApplicableTranslations($update->translations);

--- a/Puc/v4p4/UpdateChecker.php
+++ b/Puc/v4p4/UpdateChecker.php
@@ -301,13 +301,7 @@ if ( !class_exists('Puc_v4p4_UpdateChecker', false) ):
 			//Let plugins/themes modify the update.
 			$update = apply_filters($this->getUniqueName('request_update_result'), $update, $httpResult);
 
-			// "Tested up to" field in the plugin metadata is supposed to be in form of "major.minor",
-			// while WordPress core's list_plugin_updates() expects the $update->tested field to be
-			// the exact version, e.g. "major.minor.patch", to say it's compatible. In other case it would
-			// show "Compatibility: Unknown". That kinda mimics how wordpress.org API handles the "tested" field.
-			if (isset($update->tested) && preg_match('/^\d+\.\d+$/', $update->tested)) {
-				$update->tested .= ".999";
-			}
+			$this->fixSupportedWordpressVersion($update);
 
 			if ( isset($update, $update->translations) ) {
 				//Keep only those translation updates that apply to this site.
@@ -315,6 +309,48 @@ if ( !class_exists('Puc_v4p4_UpdateChecker', false) ):
 			}
 
 			return $update;
+		}
+
+		/**
+		 * The "Tested up to" field in the plugin metadata is supposed to be in the form of "major.minor",
+		 * while WordPress core's list_plugin_updates() expects the $update->tested field to be an exact
+		 * version, e.g. "major.minor.patch", to say it's compatible. In other case it shows
+		 * "Compatibility: Unknown".
+		 * The function mimics how wordpress.org API crafts the "tested" field out of "Tested up to".
+		 *
+		 * @param Puc_v4p4_Update|null $update
+		 */
+		private function fixSupportedWordpressVersion(Puc_v4p4_Update $update = null) {
+
+			if (!isset($update->tested) || !preg_match('/^\d++\.\d++$/', $update->tested)) {
+				return;
+			}
+
+			$actualWpVersions = array(); {
+
+				$wpVersion = $GLOBALS['wp_version'];
+
+				if ( function_exists('get_preferred_from_update_core') ) {
+					$coreUpdate = get_preferred_from_update_core();
+					if ( isset($coreUpdate->current) && version_compare($coreUpdate->current, $wpVersion, '>') ) {
+						$actualWpVersions[] = $coreUpdate->current;
+					}
+				}
+
+				$actualWpVersions[] = $wpVersion;
+			}
+
+			$actualWpPatchNumber = "999";
+			foreach ( $actualWpVersions as $version ) {
+				if ( preg_match('/^(?P<majorMinor>\d++\.\d++)\.(?P<patch>\d++)/', $version, $versionParts) ) {
+					if ( $versionParts['majorMinor'] === $update->tested ) {
+						$actualWpPatchNumber = $versionParts['patch'];
+						break;
+					}
+				}
+			}
+
+			$update->tested .= '.' . $actualWpPatchNumber;
 		}
 
 		/**

--- a/Puc/v4p4/UpdateChecker.php
+++ b/Puc/v4p4/UpdateChecker.php
@@ -326,19 +326,20 @@ if ( !class_exists('Puc_v4p4_UpdateChecker', false) ):
 				return;
 			}
 
-			$actualWpVersions = array(); {
 
-				$wpVersion = $GLOBALS['wp_version'];
+			$actualWpVersions = array();
 
-				if ( function_exists('get_preferred_from_update_core') ) {
-					$coreUpdate = get_preferred_from_update_core();
-					if ( isset($coreUpdate->current) && version_compare($coreUpdate->current, $wpVersion, '>') ) {
-						$actualWpVersions[] = $coreUpdate->current;
-					}
+			$wpVersion = $GLOBALS['wp_version'];
+
+			if ( function_exists('get_preferred_from_update_core') ) {
+				$coreUpdate = get_preferred_from_update_core();
+				if ( isset($coreUpdate->current) && version_compare($coreUpdate->current, $wpVersion, '>') ) {
+					$actualWpVersions[] = $coreUpdate->current;
 				}
-
-				$actualWpVersions[] = $wpVersion;
 			}
+
+			$actualWpVersions[] = $wpVersion;
+
 
 			$actualWpPatchNumber = "999";
 			foreach ( $actualWpVersions as $version ) {

--- a/Puc/v4p4/UpdateChecker.php
+++ b/Puc/v4p4/UpdateChecker.php
@@ -320,7 +320,7 @@ if ( !class_exists('Puc_v4p4_UpdateChecker', false) ):
 		 *
 		 * @param Puc_v4p4_Update|null $update
 		 */
-		private function fixSupportedWordpressVersion(Puc_v4p4_Update $update = null) {
+		protected function fixSupportedWordpressVersion(Puc_v4p4_Update $update = null) {
 
 			if (!isset($update->tested) || !preg_match('/^\d++\.\d++$/', $update->tested)) {
 				return;


### PR DESCRIPTION
(Tested with WordPress 4.9.6 and Plugin Update Checker f26378d0c2224f8132582966fb1978c8142d6593)

The `Tested up to` field in the plugin metadata is supposed to be in form of "major.minor", while WordPress core (the `list_plugin_updates()` function) expects the `$update->tested` field to be the exact version, e.g. "major.minor.patch", to say it's compatible with installed WordPress version. If `$update->tested` doesn't contain the patch part, WordPress shows "Compatibility: Unknown". 

WordPress.org API actually adds the patch part to what is specified in `Tested up to`, so, for example, `Tested up to = 4.9` becomes `tested = 4.9.6` in the API response, where `6` is the last WordPress patch number. The suggested change makes Plugin Update Checker to mimic that behavior.


Before: 
![plugin-update-checker-unknown-compat](https://user-images.githubusercontent.com/345718/41507991-d209c2c4-7245-11e8-9ecb-e207b3c527d9.png)


After:
![plugin-update-checker-nice-compat](https://user-images.githubusercontent.com/345718/41507994-d5c99e7a-7245-11e8-92f9-29704387d04c.png)



