### PR TITLE
Add package to allow custom installation path.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "yahnis-elsts/plugin-update-checker",
-	"type": "library",
+	"type": "wordpress-dropin",
 	"description": "A custom update checker for WordPress plugins and themes. Useful if you can't host your plugin in the official WP repository but still want it to support automatic updates.",
 	"keywords": ["wordpress", "plugin updates", "automatic updates", "theme updates"],
 	"homepage": "https://github.com/YahnisElsts/plugin-update-checker/",
@@ -14,7 +14,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.2.0"
+		"php": ">=5.2.0",
+		"composer/installers": "~1.0"
 	},
 	"autoload": {
 		"files": ["plugin-update-checker.php"]


### PR DESCRIPTION
Hi! I'd love to be able to use Composer to install this package into a custom path rather than the `vendor` directory. To do this requires the change I've made here. The only question I have is on the impact of changing the type to `wordpress-dropin` and how that might impact other consumers. This change is required by the Installers package, which only supports a limited number of types. 

https://github.com/composer/installers#current-supported-package-types