### PR TITLE
Fix typo in DebugBar extension availability check

### DIFF
--- a/Puc/v4p4/UpdateChecker.php
+++ b/Puc/v4p4/UpdateChecker.php
@@ -883,7 +883,7 @@ if ( !class_exists('Puc_v4p4_UpdateChecker', false) ):
 		 * Initialize the update checker Debug Bar plugin/add-on thingy.
 		 */
 		public function maybeInitDebugBar() {
-			if ( class_exists('Debug_Bar', false) && file_exists(dirname(__FILE__ . '/DebugBar')) ) {
+			if ( class_exists('Debug_Bar', false) && file_exists(dirname(__FILE__) . '/DebugBar') ) {
 				$this->createDebugBarExtension();
 			}
 		}


### PR DESCRIPTION
Without the fix it gives a fatal error when the Debug Bar plugin is active and `Puc/p4v4/DebugBar` folder doesn't exist. 