### PR TITLE
export-ignore files an end-user doesn't need

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.editorconfig export-ignore
+composer.json export-ignore
+license.txt export-ignore
+README.md export-ignore
+/css export-ignore
+/js export-ignore
+/examples export-ignore
+/Puc/v4p4/DebugBar export-ignore


### PR DESCRIPTION
It's a common practice to mark files which end-users don't need with export-ignore git attribute. It usually includes tests, docs, examples, etc; everything required for development but not needed for usage. For example, no users of a WordPress plugin with PUC seem to be interested in `composer.json' and '.gitignore' files.

Files marked with export-ignore won't appear in 'dist' packages such as ones on the `releases` github page or installed with `composer --prefer-dist`. 