### PR TITLE
Fix GitLab download URLs

### DIFF
--- a/Puc/v4p4/Vcs/GitLabApi.php
+++ b/Puc/v4p4/Vcs/GitLabApi.php
@@ -73,7 +73,7 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 		 * @return Puc_v4p4_Vcs_Reference|null
 		 */
 		public function getLatestTag() {
-			$tags = $this->api('/:user/:repo/repository/tags');
+			$tags = $this->api('/:id/repository/tags');
 			if ( is_wp_error($tags) || empty($tags) || !is_array($tags) ) {
 				return null;
 			}
@@ -99,7 +99,7 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 		 * @return null|Puc_v4p4_Vcs_Reference
 		 */
 		public function getBranch($branchName) {
-			$branch = $this->api('/:user/:repo/repository/branches/' . $branchName);
+			$branch = $this->api('/:id/repository/branches/' . $branchName);
 			if ( is_wp_error($branch) || empty($branch) ) {
 				return null;
 			}
@@ -124,7 +124,7 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 		 * @return string|null
 		 */
 		public function getLatestCommitTime($ref) {
-			$commits = $this->api('/:user/:repo/repository/commits/', array('ref_name' => $ref));
+			$commits = $this->api('/:id/repository/commits/', array('ref_name' => $ref));
 			if ( is_wp_error($commits) || !is_array($commits) || !isset($commits[0]) ) {
 				return null;
 			}
@@ -179,7 +179,8 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 		protected function buildApiUrl($url, $queryParams) {
 			$variables = array(
 				'user' => $this->userName,
-				'repo' => $this->repositoryName
+				'repo' => $this->repositoryName,
+				'id'   => $this->userName . '/' . $this->repositoryName,
 			);
 
 			foreach ($variables as $name => $value) {
@@ -224,12 +225,11 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 		 */
 		public function buildArchiveDownloadUrl($ref = 'master') {
 			$url = sprintf(
-				'https://%1$s/%2$s/%3$s/repository/%4$s/archive.zip',
+				'https://%1$s/api/v4/projects/%2$s/repository/archive.zip',
 				$this->repositoryHost,
-				urlencode($this->userName),
-				urlencode($this->repositoryName),
-				urlencode($ref)
+				urlencode($this->userName . '/' . $this->repositoryName)
 			);
+			$url = add_query_arg('sha', urlencode($ref), $url);
 
 			if ( !empty($this->accessToken) ) {
 				$url = add_query_arg('private_token', $this->accessToken, $url);

--- a/Puc/v4p4/Vcs/GitLabApi.php
+++ b/Puc/v4p4/Vcs/GitLabApi.php
@@ -209,7 +209,7 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 		 * @return null|string Either the contents of the file, or null if the file doesn't exist or there's an error.
 		 */
 		public function getRemoteFile($path, $ref = 'master') {
-			$response = $this->api('/:user/:repo/repository/files/' . $path, array('ref' => $ref));
+			$response = $this->api('/:id/repository/files/' . $path, array('ref' => $ref));
 			if ( is_wp_error($response) || !isset($response->content) || $response->encoding !== 'base64' ) {
 				return null;
 			}

--- a/Puc/v4p4/Vcs/GitLabApi.php
+++ b/Puc/v4p4/Vcs/GitLabApi.php
@@ -184,10 +184,10 @@ if ( !class_exists('Puc_v4p4_Vcs_GitLabApi', false) ):
 			);
 
 			foreach ($variables as $name => $value) {
-				$url = str_replace("/:{$name}", urlencode('/' . $value), $url);
+				$url = str_replace("/:{$name}", '/' . urlencode($value), $url);
 			}
 
-			$url = substr($url, 3);
+			$url = substr($url, 1);
 			$url = sprintf('https://%1$s/api/v4/projects/%2$s', $this->repositoryHost, $url);
 
 			if ( !empty($this->accessToken) ) {


### PR DESCRIPTION
The old way of downloading branch/tag archives no longer works due to recent changes to the GitLab API. These patches should fix that. See #240 for details and discussion.