### PR TITLE
Add a filter to getVcsService

### DIFF
--- a/Puc/v4p5/Factory.php
+++ b/Puc/v4p5/Factory.php
@@ -207,8 +207,8 @@ if ( !class_exists('Puc_v4p5_Factory', false) ):
 					$service = $knownServices[$host];
 				}
 			}
-      
-			return $service;
+			
+			return apply_filter('puc_get_vcs_service', $service, $host, $path, $metadataUrl);
 		}
 
 		/**


### PR DESCRIPTION
The filter 'puc_get_vcs_service' will then allow user to add their self hosted gitlab or bitbucket as a recognised service
like so
```php
add_filter( 'puc_get_vcs_service', function( $service, $host ) {
    if ($host == 'gitlab.mydomain.com') {
        return 'GitLab';
    }
    return $service;
}, 10, 2);
```