### PR TITLE
Add a filter hook into getInstalledVersion()

### DIFF
--- a/Puc/v4p5/UpdateChecker.php
+++ b/Puc/v4p5/UpdateChecker.php
@@ -377,7 +377,7 @@ if ( !class_exists('Puc_v4p5_UpdateChecker', false) ):
 		 * @return string|null Version number.
 		 */
 		public function getInstalledVersion() {
-			return $this->package->getInstalledVersion();
+			return apply_filters($this->getUniqueName('get_installed_version'), $this->package->getInstalledVersion());
 		}
 
 		/**


### PR DESCRIPTION
This allows for plugin/theme developers to force re-installs when version numbers match.

Here is an example snippet that a theme could write in its `functions.php` to force a re-install of their theme from remote via PUC:
```php
//Perhaps wrap this in a conditional to run only when re-install is desired
add_filter('puc_get_installed_version_theme-Nebula', function($version){ //This hook is unique to the theme/plugin name
	return '2.3.4'; //An arbitrary version number that is earlier that the remote version. Could simply be "1" or "0.0.1"
});

add_action('admin_init', function(){
	//Require and init/build PUC here (just like normal). In this case I set it to $theme_update_checker
	
	$theme_update_checker->resetUpdateState(); //Reset the PUC cache
	$theme_update_checker->checkForUpdates(); //Check for a new update (which will be overridden by the above filter)
});
```

#277 