### PR TITLE
Added conditional to prevent fatal error when CRON is disabled

### DIFF
--- a/Puc/v4p11/UpdateChecker.php
+++ b/Puc/v4p11/UpdateChecker.php
@@ -338,11 +338,13 @@ if ( !class_exists('Puc_v4p11_UpdateChecker', false) ):
 			//Let plugins/themes modify the update.
 			$update = apply_filters($this->getUniqueName('request_update_result'), $update, $httpResult);
 
-			$this->fixSupportedWordpressVersion($update);
+			if ( !empty($update) ) {
+				$this->fixSupportedWordpressVersion($update);
 
-			if ( isset($update, $update->translations) ) {
-				//Keep only those translation updates that apply to this site.
-				$update->translations = $this->filterApplicableTranslations($update->translations);
+				if ( isset($update, $update->translations) ) {
+					//Keep only those translation updates that apply to this site.
+					$update->translations = $this->filterApplicableTranslations($update->translations);
+				}
 			}
 
 			return $update;
@@ -670,7 +672,7 @@ if ( !class_exists('Puc_v4p11_UpdateChecker', false) ):
 			$result = wp_remote_get($url, $options);
 
 			$result = apply_filters($this->getUniqueName('request_metadata_http_result'), $result, $url, $options);
-			
+
 			//Try to parse the response
 			$status = $this->validateApiResponse($result);
 			$metadata = null;


### PR DESCRIPTION
If `$update` is ever false this will prevent a fatal error on the `update-core.php` page.

Related: https://github.com/YahnisElsts/plugin-update-checker/issues/425

I played around with this some more and found that this conditional prevents the error. Again, I don't know if this is something that would be better to fix upstream, but hope this helps shed some light at least!