### PR TITLE
Adds possible default branch name 'main': Bitbucket

### DIFF
--- a/Puc/v4p11/Vcs/BitBucketApi.php
+++ b/Puc/v4p11/Vcs/BitBucketApi.php
@@ -42,7 +42,7 @@ if ( !class_exists('Puc_v4p11_Vcs_BitBucketApi', false) ):
 			$updateSource = $this->getStableTag($configBranch);
 
 			//Look for version-like tags.
-			if ( !$updateSource && ($configBranch === 'master') ) {
+			if ( !$updateSource && ($configBranch === 'master' || $configBranch === 'main') ) {
 				$updateSource = $this->getLatestTag();
 			}
 			//If all else fails, use the specified branch itself.


### PR DESCRIPTION
Adds `main` as a possible default branch name to invoke `$this->getLatestTag()` inside of `Puc_v4p11_Vcs_BitBucketApi::chooseReference()`.

Previously, only branches named `master` inherited this special behavior. With more VCS providers opting for an inclusive default branch name, this commit adds `main` as a default branch name configuration.

Related to #422.