### PR TITLE
Use plugin screenshots from the local "assets" directory.

### DIFF
--- a/Puc/v4p11/Autoloader.php
+++ b/Puc/v4p11/Autoloader.php
@@ -21,7 +21,7 @@ if ( !class_exists('Puc_v4p11_Autoloader', false) ):
 			$this->libraryDir = $this->libraryDir . '/';
 
 			$this->staticMap = array(
-				'PucReadmeParser' => 'vendor/PucReadmeParser.php',
+				'PucReadmeParser_v4p11' => 'vendor/PucReadmeParser.php',
 				'Parsedown' => 'vendor/Parsedown.php',
 				'Puc_v4_Factory' => 'Puc/v4/Factory.php',
 			);

--- a/Puc/v4p11/Vcs/Api.php
+++ b/Puc/v4p11/Vcs/Api.php
@@ -65,7 +65,7 @@ if ( !class_exists('Puc_v4p11_Vcs_Api') ):
 				return array();
 			}
 
-			$parser = new PucReadmeParser();
+			$parser = new PucReadmeParser_v4p11();
 			return $parser->parse_readme_contents($fileContents);
 		}
 

--- a/vendor/PucReadmeParser.php
+++ b/vendor/PucReadmeParser.php
@@ -1,13 +1,13 @@
 <?php
 
-if ( !class_exists('PucReadmeParser', false) ):
+if ( !class_exists('PucReadmeParser_v4p11', false) ):
 
 /**
  * This is a slightly modified version of github.com/markjaquith/WordPress-Plugin-Readme-Parser
  * It uses Parsedown instead of the "Markdown Extra" parser.
  */
 
-class PucReadmeParser {
+class PucReadmeParser_v4p11 {
 
 	function __construct() {
 		// This space intentionally blank

--- a/vendor/PucReadmeParser.php
+++ b/vendor/PucReadmeParser.php
@@ -157,8 +157,44 @@ class PucReadmeParser {
 		if ( isset($final_sections['screenshots']) ) {
 			preg_match_all('|<li>(.*?)</li>|s', $final_sections['screenshots'], $screenshots, PREG_SET_ORDER);
 			if ( $screenshots ) {
-				foreach ( (array) $screenshots as $ss )
-					$final_screenshots[] = $ss[1];
+				/**
+				 * Parse Screenshots from Readme.txt
+				 *
+				 * Refer to @link https://wordpress.org/plugins/readme.txt
+				 * and @link https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/ of the standard
+				 */
+				$assetDirectory = realpath(dirname( __FILE__ ) . '/../../' ) . DIRECTORY_SEPARATOR . 'assets';
+				$assetBaseUrl = trailingslashit(plugins_url('', $assetDirectory . '/imaginary.file'));
+				$ss_prefix = 'screenshot-';
+				$ss_count = 1;
+
+				foreach ( (array) $screenshots as $ss ) {
+					$ss_text = $ss[1];
+					$ss_url = null;
+
+					$filename_path = trailingslashit($assetDirectory) . $ss_prefix . $ss_count;
+					$filename_url = $assetBaseUrl . $ss_prefix . $ss_count;
+					/**
+					 * @link https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
+					 */
+					if ( is_file( $filename_path . '.png') ) {
+						$ss_url = $filename_url . '.png';
+					} elseif ( is_file( $filename_path . '.jpg') ) {
+						$ss_url = $filename_url . '.jpg';
+					}
+
+					if ( ! empty($ss_url) ) {
+						$ss_html = '<li>';
+							$ss_html .= '<img src="'.$ss_url.'" alt="'.$ss_text.'" />';
+							$ss_html .= '<p>'.$ss_text.'</p>';
+						$ss_html .= '</li>';
+						$final_screenshots[] = $ss_html;
+					} else {
+						$final_screenshots[] = '<li>' . $ss_text . '</li>';
+					}
+					$ss_count++;
+				}
+				$final_sections['screenshots'] = '<ol>'.implode('',$final_screenshots).'</ol>';
 			}
 		}
 


### PR DESCRIPTION
Just like the icons and banners we can use screenshots from the assets directory

However the implmention needs to be slightly different as the screenshot captions are extracted from the readme.txt file and the screenshot files from the assets directory.

WP Standards taken from 
- https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
- https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/
- https://wordpress.org/plugins/readme.txt