### PR TITLE
Randomize firstCheckTime into the future, rather than scheduling in the past

### DIFF
--- a/Puc/v4p11/Scheduler.php
+++ b/Puc/v4p11/Scheduler.php
@@ -53,7 +53,7 @@ if ( !class_exists('Puc_v4p11_Scheduler', false) ):
 				if ( !wp_next_scheduled($this->cronHook) && !defined('WP_INSTALLING') ) {
 					//Randomly offset the schedule to help prevent update server traffic spikes. Without this
 					//most checks may happen during times of day when people are most likely to install new plugins.
-					$firstCheckTime = time() - rand(0, max($this->checkPeriod * 3600 - 15 * 60, 1));
+					$firstCheckTime = time() + rand(0, max($this->checkPeriod * 3600 - 15 * 60, 1));
 					$firstCheckTime = apply_filters(
 						$this->updateChecker->getUniqueName('first_check_time'),
 						$firstCheckTime


### PR DESCRIPTION
Presently a random offset is subtracted from time() and scheduled (such that the event is scheduled in the past, causing the job to execute on each WP-Cron execution since the scheduled time has passed). PR changes this to schedule the next update cycle at a randomized time in the future.