### PR TITLE
Fix PHP 8.4 deprecation errors

### DIFF
--- a/Puc/v5p5/StateStore.php
+++ b/Puc/v5p5/StateStore.php
@@ -77,7 +77,7 @@ if ( !class_exists(StateStore::class, false) ):
 		 * @param Update|null $update
 		 * @return $this
 		 */
-		public function setUpdate(Update $update = null) {
+		public function setUpdate(?Update $update = null) {
 			$this->lazyLoad();
 			$this->update = $update;
 			return $this;

--- a/Puc/v5p5/UpdateChecker.php
+++ b/Puc/v5p5/UpdateChecker.php
@@ -459,7 +459,7 @@ if ( !class_exists(UpdateChecker::class, false) ):
 		 *
 		 * @param Metadata|null $update
 		 */
-		protected function fixSupportedWordpressVersion(Metadata $update = null) {
+		protected function fixSupportedWordpressVersion(?Metadata $update = null) {
 			if ( !isset($update->tested) || !preg_match('/^\d++\.\d++$/', $update->tested) ) {
 				return;
 			}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6.20",
+		"php": ">=7.1",
 		"ext-json": "*"
 	},
 	"autoload": {

--- a/vendor/ParsedownModern.php
+++ b/vendor/ParsedownModern.php
@@ -648,7 +648,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -786,7 +786,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {


### PR DESCRIPTION
Change type declarations to explicitly as nullable
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

This also bumps PHP requirement to 7.1, since nullable types is a PHP 7.1 feature.

```
Deprecated: YahnisElsts\PluginUpdateChecker\v5p5\UpdateChecker::fixSupportedWordpressVersion(): Implicitly marking parameter $update as nullable is deprecated, the explicit nullable type must be used instead
```