### PR TITLE
Fix PHP 8.4 deprecation errors pt. 2

### DIFF
--- a/Puc/v5p5/StateStore.php
+++ b/Puc/v5p5/StateStore.php
@@ -77,7 +77,7 @@ if ( !class_exists(StateStore::class, false) ):
 		 * @param Update|null $update
 		 * @return $this
 		 */
-		public function setUpdate(Update $update = null) {
+		public function setUpdate($update = null) {
 			$this->lazyLoad();
 			$this->update = $update;
 			return $this;

--- a/Puc/v5p5/UpdateChecker.php
+++ b/Puc/v5p5/UpdateChecker.php
@@ -459,7 +459,7 @@ if ( !class_exists(UpdateChecker::class, false) ):
 		 *
 		 * @param Metadata|null $update
 		 */
-		protected function fixSupportedWordpressVersion(Metadata $update = null) {
+		protected function fixSupportedWordpressVersion($update = null) {
 			if ( !isset($update->tested) || !preg_match('/^\d++\.\d++$/', $update->tested) ) {
 				return;
 			}

--- a/vendor/ParsedownModern.php
+++ b/vendor/ParsedownModern.php
@@ -648,7 +648,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -786,7 +786,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {


### PR DESCRIPTION
Remove type declarations for parameters that are nullable to get rid of deprecation errors in a backwards compatible way.