### PR TITLE
Add autoupdate field to plugin update info to force update the plugin

### DIFF
--- a/Puc/v5p6/Plugin/PluginInfo.php
+++ b/Puc/v5p6/Plugin/PluginInfo.php
@@ -39,7 +39,7 @@ if ( !class_exists(PluginInfo::class, false) ):
 		public $downloaded;
 		public $active_installs;
 		public $last_updated;
-		public $autoupdate;
+		public $autoupdate = false;
 
 		public $id = 0; //The native WP.org API returns numeric plugin IDs, but they're not used for anything.
 

--- a/Puc/v5p6/Plugin/PluginInfo.php
+++ b/Puc/v5p6/Plugin/PluginInfo.php
@@ -39,6 +39,7 @@ if ( !class_exists(PluginInfo::class, false) ):
 		public $downloaded;
 		public $active_installs;
 		public $last_updated;
+		public $autoupdate;
 
 		public $id = 0; //The native WP.org API returns numeric plugin IDs, but they're not used for anything.
 

--- a/Puc/v5p6/Plugin/Update.php
+++ b/Puc/v5p6/Plugin/Update.php
@@ -20,7 +20,7 @@ if ( !class_exists(Update::class, false) ):
 		public $requires_php = false;
 		public $icons = array();
 		public $filename; //Plugin filename relative to the plugins directory.
-		public $autoupdate;
+		public $autoupdate = false;
 
 		protected static $extraFields = array(
 			'id', 'homepage', 'tested', 'requires_php', 'upgrade_notice', 'icons', 'filename', 'autoupdate',

--- a/Puc/v5p6/Plugin/Update.php
+++ b/Puc/v5p6/Plugin/Update.php
@@ -20,9 +20,10 @@ if ( !class_exists(Update::class, false) ):
 		public $requires_php = false;
 		public $icons = array();
 		public $filename; //Plugin filename relative to the plugins directory.
+		public $autoupdate;
 
 		protected static $extraFields = array(
-			'id', 'homepage', 'tested', 'requires_php', 'upgrade_notice', 'icons', 'filename',
+			'id', 'homepage', 'tested', 'requires_php', 'upgrade_notice', 'icons', 'filename', 'autoupdate',
 		);
 
 		/**
@@ -86,6 +87,7 @@ if ( !class_exists(Update::class, false) ):
 			$update->tested = $this->tested;
 			$update->requires_php = $this->requires_php;
 			$update->plugin = $this->filename;
+			$update->autoupdate = $this->autoupdate;
 
 			if ( !empty($this->upgrade_notice) ) {
 				$update->upgrade_notice = $this->upgrade_notice;


### PR DESCRIPTION
I want to add the ability to be able to force update the plugin. This is useful when we have a security issue in our plugin, and we want to roll up the updates that fix it to all our users immediately.

I found that we can do this by adding the `autoupdate` field to the plugin update info. If this field is present and its value is `true`, then WordPress will force update the plugin on the next auto update cron schedule.