### PR TITLE
Handle body error

### DIFF
--- a/Puc/v5p6/UpdateChecker.php
+++ b/Puc/v5p6/UpdateChecker.php
@@ -813,9 +813,28 @@ if ( !class_exists(UpdateChecker::class, false) ):
 			}
 
 			if ( $result['response']['code'] !== 200 ) {
+				$error_message = 'HTTP response code is ' . $result['response']['code'] . ' (expected: 200)';
+				
+				// Try to extract error message from response body if available
+				if ( !empty($result['body']) ) {
+					$body = trim($result['body']);
+					// Try to parse as JSON
+					$decoded = json_decode($body, true);
+					if ( json_last_error() === JSON_ERROR_NONE && is_array($decoded) ) {
+						if ( isset($decoded['error']) && is_string($decoded['error']) ) {
+							$error_message .= '. Error: ' . $decoded['error'];
+						} elseif ( isset($decoded['message']) && is_string($decoded['message']) ) {
+							$error_message .= '. Message: ' . $decoded['message'];
+						}
+					} elseif ( !empty($body) && strlen($body) < 500 ) {
+						// If not JSON but short text, include it
+						$error_message .= '. Response: ' . $body;
+					}
+				}
+				
 				return new WP_Error(
 					'puc_unexpected_response_code',
-					'HTTP response code is ' . $result['response']['code'] . ' (expected: 200)'
+					$error_message
 				);
 			}
 


### PR DESCRIPTION
my plugin https://github.com/maxkcy/puc-lmfwc-server (if you can take a look) in function send_error_response can send a different code, and this pull request is to display the custom error message
```
    /**
     * Send error response
     */
    private function send_error_response( $message, $response_code = 400 ) {
        try {
        self::puc_lmfwc_server_log_info( "Error response: {$message}" );
        
        header( 'Content-Type: application/json' );
        http_response_code( $response_code );
        echo json_encode( array( 'error' => $message ) );
        exit;
        } catch (Exception $e) {
            error_log('PUC LMFWC Server: An error occurred when trying to send error response: ' . $e->getMessage());
        }
    }
```

